### PR TITLE
Release of "5.0.0rc9_INTERIM_16"

### DIFF
--- a/brainannex/__init__.py
+++ b/brainannex/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.0.0rc9_INTERIM_15"
+__version__ = "5.0.0rc9_INTERIM_16"
 # TODO: consider using names such as 5.0.0-rc.8.6 , to conform to https://semver.org/
 
 # IMPORTANT: ONLY 1 of the following small group of InterGraph imports

--- a/brainannex/graph_schema.py
+++ b/brainannex/graph_schema.py
@@ -1216,12 +1216,12 @@ class GraphSchema:
 
 
         :param class_name:          The name of a Schema Class
-        :param include_ancestors:   If True, also include the Properties attached to Classes that are ancestral
+        :param include_ancestors:   [OPTIONAL] If True, also include the Properties attached to Classes that are ancestral
                                     to the given one by means of a chain of outbound "INSTANCE_OF" relationships
                                     Note: the sorting by relationship index won't mean much if ancestral nodes are included,
                                           with their own indexing of relationships; if order matters in those cases, use the
                                           "sort_by_path_len" argument, below
-        :param sort_by_path_len:    Only applicable if include_ancestors is True.
+        :param sort_by_path_len:    [OPTIONAL] Only applicable if include_ancestors is True.
                                         If provided, it must be either "ASC" or "DESC", and it will sort the results by path length
                                         (either ascending or descending), before sorting by the schema-specified position for each Class.
                                         Note: with "ASC", the immediate Properties of the given Class will be listed first
@@ -1273,7 +1273,8 @@ class GraphSchema:
 
 
     @classmethod
-    def get_class_properties_full_data(cls, class_name: str) -> [dict]:
+    def get_class_properties_full_data(cls, class_name: str,
+                                       include_ancestors=False, exclude_system=False) -> [dict]:
         """
         Return the full data (not just the names) for all the Properties of the given Schema Class,
         as a list of dictionaries.
@@ -1285,25 +1286,55 @@ class GraphSchema:
               'dtype': 'string', 'description': 'the body of the quote', 'required': True, 'system': False, 'format': '6,50'}
             ]
 
-        :param class_name:  The name of a Schema Class
-        :return:            A (possibly-empty) list of Property data for the above class.
-                                The node labels are excluded from the returned data,
-                                but the internal database ID's are returned, using the key '_internal_id'
+        :param class_name:          The name of a Schema Class
+        :param include_ancestors:   [OPTIONAL] If True, also include the Properties attached to Classes that are ancestral
+                                        to the given one by means of a chain of outbound "INSTANCE_OF" relationships;
+                                        the immediate Properties of the given Class will be listed first.
+                                        Default is False
+        :param exclude_system:      [OPTIONAL] If True, Property nodes with the attribute "system" set to True will be excluded.
+                                        Default is False
+        :return:                    A (possibly-empty) list of Property data for the above class.
+                                        The node labels are excluded from the returned data,
+                                        but the internal database ID's are returned, using the key '_internal_id'
         """
         # TODO: if the Class isn't present, an Exception ought to get raised
-        q = f'''
-            MATCH (c :CLASS)-[r :HAS_PROPERTY]->(p :PROPERTY)
-                WHERE c.name=$class_name
-            RETURN p
-            ORDER BY r.index
-            '''
+
+        if type(class_name) == str:
+            clause = "c.name=$class_name"
+        else:
+            raise Exception(f"get_class_properties_full_data(): argument `class_name` must be a string;"
+                            f"the value passed was of type {type(class_name)}")
+
+        if exclude_system:
+            clause += " AND (p.system IS NULL  OR  p.system = false)"
+
+
+        if include_ancestors:
+            # Follow zero or more outbound "INSTANCE_OF" relationships from the given Class node;
+            #   "zero" relationships means the original node itself (handy in situations when there are no such relationships)
+            q = f'''
+                MATCH path=(c :CLASS)-[:INSTANCE_OF*0..]->(c_ancestor)
+                                                        -[r:HAS_PROPERTY]->(p :PROPERTY)
+                WHERE {clause}
+                RETURN p
+                ORDER BY length(path) ASC, r.index
+                '''
+        else:
+            q = f'''
+                MATCH (c :CLASS)-[r :HAS_PROPERTY]->(p :PROPERTY)
+                WHERE {clause}
+                RETURN p
+                ORDER BY r.index
+                '''
+
         data_binding = {"class_name": class_name}
         return cls.db.query_extended(q, data_binding=data_binding, flatten=True, fields_to_exclude="_node_labels")
 
 
 
     @classmethod
-    def get_or_estimate_class_properties(cls, class_name: str, sample_size=300) -> [dict]:
+    def get_or_estimate_class_properties(cls, class_name: str, include_ancestors=False, exclude_system=False,
+                                         sample_size=300) -> [dict]:
         """
         If the given Class is present in the Schema, return its Properties (with their available parameters);
         otherwise, estimate the property names of database nodes with that value as a label,
@@ -1311,15 +1342,24 @@ class GraphSchema:
 
         In other words, this function gracefully degrades as needed, from Schema-based to non-schema.
 
-        :param class_name:  The name of the Entity of interest.
-                                If present as a registered Class in the database Schema, it will be interpreted as such;
-                                otherwise, it will interpreted as a database node label
+        :param class_name:          The name of the Entity of interest.
+                                        If present as a registered Class in the database Schema, it will be interpreted as such;
+                                        otherwise, it will interpreted as a database node label
+
+        :param include_ancestors:   [OPTIONAL] If True, also include the Properties attached to Classes that are ancestral
+                                        to the given one by means of a chain of outbound "INSTANCE_OF" relationships;
+                                        the immediate Properties of the given Class will be listed first.
+                                        Default is False
+        :param exclude_system:      [OPTIONAL] If True, Property nodes with the attribute "system" set to True will be excluded.
+                                        Default is False
+
         :param sample_size: [OPTIONAL] Only applicable if the database lacks a Class with the above name.
                                 Number of database nodes, with a label matching the above name,
                                 to use as a representative sampler.
                                 Use 0 or None to indicate that no sampling is to be performed, i.e. to disable fallback;
                                 in that case an empty list will be returned if there's no Schema data.
                                 If `sample_size` is non-zero, and no nodes are found with that label, an Exception is raised
+
         :return:            A list of dicts: one for each Property - either registered with the Schema,
                                 or estimated from a sampling of the data.
                                 If using the Schema, the results are ordered by the Property `order` stored in the Schema;
@@ -1335,7 +1375,9 @@ class GraphSchema:
                                     ]
         """
         if cls.class_name_exists(class_name):
-            return cls.get_class_properties_full_data(class_name)   # An integer (possibly zero if the Class has no Properties)
+            return cls.get_class_properties_full_data(class_name=class_name,
+                                                      include_ancestors=include_ancestors, exclude_system=exclude_system)
+
 
         assert sample_size, \
             f"get_or_estimate_class_properties(): the requested Class, `{class_name}`, doesn't exist, " \

--- a/brainannex/pytests/test_graph_schema.py
+++ b/brainannex/pytests/test_graph_schema.py
@@ -709,7 +709,7 @@ def test_get_class_properties(db):
     props = GraphSchema.get_class_properties("My first class")
     assert props == ["A", "B", "C"]
 
-    internal_id= GraphSchema.create_class("My BIG class")
+    GraphSchema.create_class("My BIG class")
     props = GraphSchema.get_class_properties("My BIG class")
     assert props == []
 
@@ -759,6 +759,9 @@ def test_get_class_properties(db):
                                              sort_by_path_len="DESC", exclude_system=True)
     assert props == ["X", "Z", "A", "B", "C"]
 
+    # TODO: test `exclude_system`
+
+
 
 def test_get_class_properties_full_data(db):
     db.empty_dbase()
@@ -798,8 +801,61 @@ def test_get_class_properties_full_data(db):
 
     assert GraphSchema.get_class_properties_full_data(class_name="I dont exist") == []
 
-    GraphSchema.create_class(name="Car")    # Class without Properties
+    GraphSchema.create_class(name="Car")    # Class without Properties           # This will have 'schema-5' as `entity_id`
     assert GraphSchema.get_class_properties_full_data(class_name="Car") == []
+
+    GraphSchema.add_properties_to_class(class_name="Car", properties= ["Anti-lock Brakes"])
+    GraphSchema.set_property_attribute(class_name="Car", prop_name="Anti-lock Brakes",
+                                       attribute_name="dtype", attribute_value="boolean")
+    brakes_internal_id = GraphSchema.get_property_internal_id(class_name="Car", property_name="Anti-lock Brakes")
+    result = GraphSchema.get_class_properties_full_data("Car")
+    assert result == [
+                        {'name': 'Anti-lock Brakes', 'entity_id': 'schema-6', '_internal_id': brakes_internal_id, 'dtype': 'boolean'}
+                     ]
+
+    GraphSchema.create_class_with_properties(name="Vehicle", properties=["color", "year"])  # `Vehicle` Class node will have 'schema-7'
+    GraphSchema.set_property_attribute(class_name="Vehicle", prop_name="year",
+                                       attribute_name="dtype", attribute_value="integer")
+    color_internal_id = GraphSchema.get_property_internal_id(class_name="Vehicle", property_name="color")
+    year_internal_id = GraphSchema.get_property_internal_id(class_name="Vehicle", property_name="year")
+
+    # Make "Car" Class an instance of "Vehicle"
+    GraphSchema.create_class_relationship(from_class="Car", to_class="Vehicle", rel_name="INSTANCE_OF")
+
+    result = GraphSchema.get_class_properties_full_data("Car", include_ancestors=False)
+    # Nothing has changed
+    assert result == [
+                        {'name': 'Anti-lock Brakes', 'entity_id': 'schema-6', '_internal_id': brakes_internal_id, 'dtype': 'boolean'}
+                     ]
+
+    result = GraphSchema.get_class_properties_full_data("Car", include_ancestors=True)
+    assert result == [
+                        {'name': 'Anti-lock Brakes', 'entity_id': 'schema-6', '_internal_id': brakes_internal_id, 'dtype': 'boolean'},
+                        {'name': 'color',            'entity_id': 'schema-8', '_internal_id': color_internal_id},
+                        {'name': 'year',             'entity_id': 'schema-9', '_internal_id': year_internal_id, 'dtype': 'integer'}
+                     ]
+
+
+    GraphSchema.set_property_attribute(class_name="Vehicle", prop_name="color",
+                                       attribute_name="system", attribute_value=True)
+
+    result = GraphSchema.get_class_properties_full_data("Car", include_ancestors=True, exclude_system=True)
+    assert result == [
+                        {'name': 'Anti-lock Brakes', 'entity_id': 'schema-6', '_internal_id': brakes_internal_id, 'dtype': 'boolean'},
+                        {'name': 'year',             'entity_id': 'schema-9', '_internal_id': year_internal_id, 'dtype': 'integer'}
+                     ]
+
+    GraphSchema.set_property_attribute(class_name="Car", prop_name="Anti-lock Brakes",
+                                       attribute_name="system", attribute_value=True)
+
+    result = GraphSchema.get_class_properties_full_data("Car", include_ancestors=True, exclude_system=True)
+    assert result == [
+                        {'name': 'year', 'entity_id': 'schema-9', '_internal_id': year_internal_id, 'dtype': 'integer'}
+                     ]
+
+
+    result = GraphSchema.get_class_properties_full_data("Car", include_ancestors=False, exclude_system=True)
+    assert result == []
 
 
 

--- a/flask_modules/api/BA_api_routing.py
+++ b/flask_modules/api/BA_api_routing.py
@@ -623,6 +623,8 @@ class ApiRouting:
             The JSON-encoded dict is expected to contain the following KEYS:
                 REQUIRED    "class_name"
                 OPTIONAL    "sample_size"
+                            "include_ancestors"
+                            "exclude_system"
 
             :return:
                 A response with Content-Type: application/json,
@@ -667,10 +669,15 @@ class ApiRouting:
 
 
             try:
+                # The values below will be None, if there weren't passed
                 class_name = request_parameters.get("class_name")
-                sample_size = request_parameters.get("sample_size")         # This will be None, if not passed
-                result = GraphSchema.get_or_estimate_class_properties(class_name=class_name, sample_size=sample_size)
-                                                                            # `result` is a list of dicts
+                include_ancestors = request_parameters.get("include_ancestors")
+                exclude_system = request_parameters.get("exclude_system")
+                sample_size = request_parameters.get("sample_size")
+                # `result` will be a list of dicts
+                result = GraphSchema.get_or_estimate_class_properties(class_name=class_name,
+                                                                     include_ancestors=include_ancestors, exclude_system=exclude_system,
+                                                                     sample_size=sample_size)
                 response_data = {"status": "ok", "payload": result}         # Successful termination
             except Exception as ex:
                 err_details = f"/class-properties-full-data : unable to retrieve the requested data.  " \

--- a/flask_modules/pages/static/vue_components/PLUGINS/recordset/recordset.js
+++ b/flask_modules/pages/static/vue_components/PLUGINS/recordset/recordset.js
@@ -368,7 +368,6 @@ Vue.component('vue-plugin-rs',
             return {
                 headers: [],            // A complete list of ALL the names of the table columns
                                         // EXAMPLE:  ["quote", "attribution", "notes"]
-                                        // TODO: turn into fuller Schema data, if available (or use a separate variable for that)
 
                 schema_info: [],        /*  EXAMPLE (when Schema data is available):
                                             [   {'name': 'notes', 'entity_id': 'schema-2', '_internal_id': 123,
@@ -792,14 +791,16 @@ Vue.component('vue-plugin-rs',
 
 
             /*
-                ------------------   SERVER CALLS   ------------------
+                ------------------------   SERVER CALLS   ------------------------
              */
 
-            save_record_edit()
-            /*  Invoked when the user asks to save the edit-in-progress
-                of an EXISTING INDIVIDUAL record.
-                NOT used for new records, nor to change the definition of the recordset
+
+            /**
+             *  Invoked when the user asks to save the edit-in-progress
+             *  of an EXISTING INDIVIDUAL record.
+             *  NOT used for new records, nor for changing the definition of the recordset!
              */
+            save_record_edit()
             {
                 // Send the request to the server, using a POST
                 const url_server_api = "/BA/api/update_content_item_JSON";
@@ -1108,6 +1109,8 @@ Vue.component('vue-plugin-rs',
                                  };     // TODO: also consider passing `class_name`, if present
                  */
                 const data_obj = {class_name: this.current_data.filter_label,
+                                  include_ancestors: true,
+                                  exclude_system: true,
                                   sample_size: 200
                                  };
 


### PR DESCRIPTION
Added args `include_ancestors` and `exclude_system` to GraphSchema.get_class_properties_full_data() and to get_or_estimate_class_properties() Bugfix to the recently-expanded web API '/class-properties-full-data', and concomitant change to Vue.component 'vue-plugin-rs'